### PR TITLE
Clearify manual steps

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -24,13 +24,14 @@ transfers a gerrit patch to a github pull request. In detail it does the followi
 
 #### Manually transfer a gerrit change to github
 
-These are the steps you have to do to manually move a gerrit patch to github. The example commands move a patch for the package TYPO3.TYPO3CR. If you have changes that are stacked on each other, repeat step 5 until all needed changes have been applied, then continue.
+These are the steps you have to do to manually move a Gerrit patch to Github. The example commands move a patch for the package TYPO3.TYPO3CR. If you have changes that are stacked on each other, repeat step 6 until all needed changes have been applied, then continue.
 
 1. Go to your change on https://review.typo3.org
-2. Bring your local repository and code up to date with the upstream repository
-3. Navigate to the package directory (e.g. Packages/Neos/TYPO3.TYPO3CR/)
-4. Add a new branch.
-5. Patch your code using `git am` after having copied the "fomat patch" git command. Example:
+2. If you haven't done yet, fork the Neos Development Collection repository and clone the fork on your machine
+3. Bring your local fork repository and code up to date with the upstream repository
+4. Add a new branch, for example "change-xx-yyyyy-z" or "neos-12345"
+5. Navigate to the package directory (e.g. Packages/Neos/TYPO3.TYPO3CR/)
+6. Patch your code using `git am` after having copied the "fomat patch" git command. Example:
 
    `git fetch http://review.typo3.org/Packages/TYPO3.TYPO3CR refs/changes/xx/yyyyy/z && git format-patch -1 -k --stdout FETCH_HEAD | git am -k --directory TYPO3.TYPO3CR`
 
@@ -38,11 +39,11 @@ These are the steps you have to do to manually move a gerrit patch to github. Th
    
    If you are patching a repository that is not a "development collection", you can leave out `--directory`.
 		
-6. Check the result (you may need to amend the commit to fix the [<TAG>] used in the subject line if you left
+7. Check the result (you may need to amend the commit to fix the [<TAG>] used in the subject line if you left
    out the `-k` option)
-7. Push the changes to origin/branchName
-8. Go to github and open a pull request
-9. Abandon the change on gerrit.
+8. Push the changes to origin/branchName
+9. Go to Github and open a pull request
+9. Abandon the change on Gerrit.
 
-Hint: If you are using SourceTree, steps 7 and 8 can be done by using the "Create Pull Request" item in
+Hint: If you are using SourceTree, steps 8 and 9 can be done by using the "Create Pull Request" item in
 the "Repository" menu.


### PR DESCRIPTION
This change clearifies the manual steps a little by explicitly stating that you will be working on your fork of the development collection (and not on your old package-based structure).
