### PR TITLE
[BUGFIX] changed command to avoid faulty git config

### DIFF
--- a/Classes/Neos/Contribute/Command/GitHubCommandController.php
+++ b/Classes/Neos/Contribute/Command/GitHubCommandController.php
@@ -241,7 +241,7 @@ code or documentation to the Neos Project.\n");
 		$this->executeGitCommand('git remote add origin ' . $sshUrl , $packageCollectionPath);
 		$this->executeGitCommand('git remote rm upstream', $packageCollectionPath, TRUE);
 		$this->executeGitCommand(sprintf('git remote add upstream git://github.com/%s/%s.git', $this->gitHubSettings['origin']['organization'], $originRepositoryName), $packageCollectionPath);
-		$this->executeGitCommand('git config --add remote.upstream.fetch \'+refs/pull/*/head:refs/remotes/upstream/pr/*\'', $packageCollectionPath);
+		$this->executeGitCommand('git config --add remote.upstream.fetch +refs/pull/*/head:refs/remotes/upstream/pr/*', $packageCollectionPath);
 	}
 
 


### PR DESCRIPTION
before this change the generated git config looked like this

```
[remote "upstream"]
    url = git://github.com/neos/flow-development-collection.git      
    fetch = +refs/heads/*:refs/remotes/upstream/*
    fetch = '+refs/pull/*/head:refs/remotes/upstream/pr/*'
```

causing git to crash when trying to apply a patch.

developing (and therefore running the flow commands) on a windows machine here.
